### PR TITLE
Add FastAPI web interface for chess analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ requests
 rich
 python-dotenv
 matplotlib
+fastapi
+uvicorn
+aiofiles

--- a/src/webapp.py
+++ b/src/webapp.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+from lichess_io import (
+    extract_lichess_game_id,
+    fetch_pgn_for_game,
+    parse_positions_and_clocks,
+    PositionInfo,
+)
+from openai_analyze import analyze_one_position, PositionResult
+from prompts import DEFAULT_POSITION_PROMPT
+
+load_dotenv()
+
+app = FastAPI(title="Chess Stories Web")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+class GameRequest(BaseModel):
+    url: str
+
+class AnalysisResponse(BaseModel):
+    ply: int
+    move_san: str
+    side_to_move: str
+    analysis_raw: str
+    analysis_json: dict | None
+
+# In-memory store for loaded games
+_games: Dict[str, Dict[str, any]] = {}
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    with open("static/index.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
+
+@app.post("/api/game")
+async def load_game(req: GameRequest) -> Dict[str, any]:
+    game_id = extract_lichess_game_id(req.url)
+    pgn = fetch_pgn_for_game(game_id)
+    positions, headers, move_clocks = parse_positions_and_clocks(pgn)
+    pos_meta = [
+        {
+            "ply": p.ply,
+            "fen": p.fen,
+            "move": p.move_san,
+            "move_number": p.move_number,
+            "side_to_move": p.side_to_move,
+        }
+        for p in positions
+    ]
+    _games[game_id] = {
+        "positions": positions,
+        "headers": headers,
+        "analyses": {},
+    }
+    return {"game_id": game_id, "positions": pos_meta, "headers": headers}
+
+@app.get("/api/game/{game_id}/analysis/{ply}")
+async def analyze_position(game_id: str, ply: int) -> AnalysisResponse:
+    game = _games.get(game_id)
+    if not game:
+        raise HTTPException(status_code=404, detail="Unknown game id")
+    if ply in game["analyses"]:
+        res: PositionResult = game["analyses"][ply]
+    else:
+        pos_list: List[PositionInfo] = game["positions"]
+        if ply < 1 or ply > len(pos_list):
+            raise HTTPException(status_code=404, detail="Invalid ply")
+        position = pos_list[ply - 1]
+        client_sem = asyncio.Semaphore(1)
+        from openai import AsyncOpenAI
+        client = AsyncOpenAI()
+        res = await analyze_one_position(
+            client_sem,
+            client,
+            model="gpt5-mini",
+            p=position,
+            template=DEFAULT_POSITION_PROMPT,
+        )
+        game["analyses"][ply] = res
+    data = asdict(res)
+    return AnalysisResponse(
+        ply=data["ply"],
+        move_san=data["move_san"],
+        side_to_move=data["side_to_move"],
+        analysis_raw=data["analysis_raw"],
+        analysis_json=data.get("analysis_json"),
+    )
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("src.webapp:app", host="0.0.0.0", port=8000, reload=False)

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,96 @@
+let gameId = null;
+let positions = [];
+let analyses = {};
+let board = null;
+
+function winnerLabelToScalar(label) {
+  if (label === "White") return 1;
+  if (label === "Draw") return 0.5;
+  if (label === "Black") return 0;
+  return null;
+}
+
+const ctx = document.getElementById('predictionChart').getContext('2d');
+const chart = new Chart(ctx, {
+  type: 'line',
+  data: {
+    labels: [],
+    datasets: [{
+      data: [],
+      borderColor: '#00ff99',
+      pointBackgroundColor: '#00ff99',
+      tension: 0,
+    }]
+  },
+  options: {
+    scales: {
+      y: {
+        min: 0,
+        max: 1,
+        ticks: {
+          callback: function(val){
+            if(val === 1) return 'White';
+            if(val === 0.5) return 'Draw';
+            if(val === 0) return 'Black';
+            return '';
+          }
+        }
+      }
+    },
+    plugins: {
+      legend: { display: false }
+    },
+    onClick: (evt, elements) => {
+      if(elements.length > 0){
+        const idx = elements[0].index;
+        showPosition(idx);
+      }
+    }
+  }
+});
+
+async function showPosition(idx){
+  const pos = positions[idx];
+  board.position(pos.fen);
+  document.getElementById('metadata').textContent = `Ply ${pos.ply} - ${pos.move}`;
+  if(analyses[pos.ply]){
+    renderAnalysis(idx, analyses[pos.ply]);
+  } else {
+    document.getElementById('summary').textContent = 'Analyzing...';
+    const resp = await fetch(`/api/game/${gameId}/analysis/${pos.ply}`);
+    const data = await resp.json();
+    analyses[pos.ply] = data;
+    renderAnalysis(idx, data);
+  }
+}
+
+function renderAnalysis(idx, data){
+  document.getElementById('summary').textContent = data.analysis_json ? data.analysis_json.comment : data.analysis_raw;
+  const scalar = winnerLabelToScalar(data.analysis_json ? data.analysis_json.winner_pred : null);
+  chart.data.datasets[0].data[idx] = scalar;
+  chart.update();
+}
+
+const form = document.getElementById('loadForm');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const url = document.getElementById('gameUrl').value.trim();
+  const resp = await fetch('/api/game', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({url})
+  });
+  const data = await resp.json();
+  gameId = data.game_id;
+  positions = data.positions;
+  analyses = {};
+  chart.data.labels = positions.map(p => p.ply);
+  chart.data.datasets[0].data = positions.map(_ => null);
+  chart.update();
+  if(!board){
+    board = Chessboard('board', positions[0].fen);
+  } else {
+    board.position(positions[0].fen);
+  }
+  showPosition(0);
+});

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Chess Stories</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard-1.0.0.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard-1.0.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<div id="container">
+  <form id="loadForm">
+    <input id="gameUrl" type="text" placeholder="Lichess URL or ID" />
+    <button type="submit">Load Game</button>
+  </form>
+  <canvas id="predictionChart" height="100"></canvas>
+  <div id="content">
+    <div id="board" style="width: 400px"></div>
+    <div id="info">
+      <pre id="metadata"></pre>
+      <pre id="summary"></pre>
+    </div>
+  </div>
+</div>
+<script src="/static/app.js"></script>
+</body>
+</html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,33 @@
+body {
+  background: #000;
+  color: #eee;
+  font-family: monospace;
+}
+#container {
+  padding: 1rem;
+}
+#loadForm input {
+  background: #222;
+  color: #eee;
+  border: 1px solid #444;
+  padding: 0.3rem;
+}
+#loadForm button {
+  background: #333;
+  color: #eee;
+  border: 1px solid #555;
+  padding: 0.3rem 0.6rem;
+}
+#content {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+#info {
+  width: 400px;
+}
+pre {
+  background: #111;
+  padding: 0.5rem;
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- Add FastAPI server exposing endpoints to load Lichess games and analyze individual positions
- Serve new static front-end with chessboard, prediction chart, and per-move summaries
- Include FastAPI and related packages in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b52928e414832989f8dcb627b48708